### PR TITLE
refactoring: 에러 관련 코드 위치 변경

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,6 @@ inquirer.registerPrompt("fuzzypath", require("inquirer-fuzzy-path"));
 const main = async () => {
   const { templateList, configFile } = readTemplates();
 
-  if (templateList.length === 0) {
-    throw new Error("🔥 No Exist template in .template folder");
-  }
-
   const { name, template, outputPath } = await inquirer.prompt<Common.UserInput>(
     questions(templateList, configFile.output)
   );

--- a/src/lib/readTemplates.ts
+++ b/src/lib/readTemplates.ts
@@ -32,5 +32,9 @@ export const readTemplates = () => {
     templateList.splice(configFileIndex, 1);
   }
 
+  if (templateList.length === 0) {
+    throw new Error("🔥 No Exist template in .template folder");
+  }
+
   return { templateList, configFile };
 };


### PR DESCRIPTION
### 변경 사항
`readTemplates` 함수 관련 에러 위치 함수 내부로 이동

### 변경 이유
기능적으로는 동일하게 작동하지만 다음과 같은 이유에서 코드 변경
- `readTemplates` 내부에서 발생하는 에러들은 해당 함수 내에서 처리
- `readTemplates` 함수를 사용할 시 에러 처리 불필요

안녕하세요! 좋은 오픈소스 프로젝트에 작게나마 기여하고 싶어서 pr 남기게 됐습니다..! 좋은 프로젝트 감사합니다👍